### PR TITLE
Prefix Authorization header with 'bearer'

### DIFF
--- a/ackboard.py
+++ b/ackboard.py
@@ -621,6 +621,6 @@ if __name__ == "__main__":
 
     with open(args.token_file, "r") as f:
         line = f.readline().strip()
-        headers["Authorization"] = line
+        headers["Authorization"] = "bearer " + line
 
     curses.wrapper(main)


### PR DESCRIPTION
Took me a bit of time to figure out why my token wasn't working. I should have put the 'bearer' prefix in the token file but I think others will encounter the same issue so I think it's better to add it automatically.

Very cool program!